### PR TITLE
🎁 Add support for getting emission rating data (mock)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1246,11 +1246,13 @@ async function run() {
 
 	// Get current emission level at runner location
 	const CURRENT_EMISSION_RATING = await _getCurrentEmissionLevel(RUNNER_LOCATION)
-	core.info(CURRENT_EMISSION_RATING[0].rating)
+	core.info(`Current emission rating in region ${RUNNER_LOCATION}: ${CURRENT_EMISSION_RATING[0].rating}`)
 
 	// Get forecasted emission level at runner location
-	const FORECASTED_EMISSION_RATING = await _getForecastedEmissionLevels(RUNNER_LOCATION)
-	core.info(FORECASTED_EMISSION_RATING)
+  // We don't want to print everything to console by default, to reduce noise. Rather print it to debug log.
+	const FORECASTED_EMISSION_RATINGS = await _getForecastedEmissionLevels(RUNNER_LOCATION)
+	core.info(`Successfully fetched forecasted emission ratings in region ${RUNNER_LOCATION}`)
+  core.debug(`Forecasted emission ratings in region ${RUNNER_LOCATION}: ${JSON.stringify(FORECASTED_EMISSION_RATINGS)}`)
 	
   // Determine whether to run the job or not
     // Things to tak into account:

--- a/index.js
+++ b/index.js
@@ -22,11 +22,13 @@ async function run() {
 
 	// Get current emission level at runner location
 	const CURRENT_EMISSION_RATING = await _getCurrentEmissionLevel(RUNNER_LOCATION)
-	core.info(CURRENT_EMISSION_RATING[0].rating)
+	core.info(`Current emission rating in region ${RUNNER_LOCATION}: ${CURRENT_EMISSION_RATING[0].rating}`)
 
 	// Get forecasted emission level at runner location
-	const FORECASTED_EMISSION_RATING = await _getForecastedEmissionLevels(RUNNER_LOCATION)
-	core.info(FORECASTED_EMISSION_RATING)
+  // We don't want to print everything to console by default, to reduce noise. Rather print it to debug log.
+	const FORECASTED_EMISSION_RATINGS = await _getForecastedEmissionLevels(RUNNER_LOCATION)
+	core.info(`Successfully fetched forecasted emission ratings in region ${RUNNER_LOCATION}`)
+  core.debug(`Forecasted emission ratings in region ${RUNNER_LOCATION}: ${JSON.stringify(FORECASTED_EMISSION_RATINGS)}`)
 	
   // Determine whether to run the job or not
     // Things to tak into account:


### PR DESCRIPTION
## 🤔 What

This PR does the following:
- [x] Adds support for determining the current emission rating at azure location
- [x] Adds support for determining the forecasted emission rating at azure location
- [x] Adds mock data needed to validate solution strategy

## 😃 Why

The action will determine whether to pause a job or not, and if yes, for how long. To make this decision we need to fetch data that supports this decision such as current and forecasted emission ratings. This PR willa dd support for fetching that data.

❗ This PR will only add mocks to begin with in order to validate the overall solution strategy. The action will be enhanced later to integrate with the [Carbon Aware SDK/API](https://github.com/Green-Software-Foundation/carbon-aware-sdk).